### PR TITLE
Add default_folder config setting

### DIFF
--- a/cubeboot/source/main.c
+++ b/cubeboot/source/main.c
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
     // }
     void *default_folder_ptr = (void*)get_symbol_value(symshdr, syment, symstringdata, "default_folder");
     if (default_folder_ptr != NULL && settings.default_folder != NULL) {
-        iprintf("Copying cube_logo_path: %p\n", default_folder_ptr);
+        iprintf("Copying default_folder: %p\n", default_folder_ptr);
         strcpy(default_folder_ptr, settings.default_folder);
     }
 

--- a/cubeboot/source/main.c
+++ b/cubeboot/source/main.c
@@ -315,6 +315,11 @@ int main(int argc, char **argv) {
     //     iprintf("Copying cube_logo_path: %p\n", cube_logo_ptr);
     //     strcpy(cube_logo_ptr, settings.cube_logo);
     // }
+    void *default_folder_ptr = (void*)get_symbol_value(symshdr, syment, symstringdata, "default_folder");
+    if (default_folder_ptr != NULL && settings.default_folder != NULL) {
+        iprintf("Copying cube_logo_path: %p\n", default_folder_ptr);
+        strcpy(default_folder_ptr, settings.default_folder);
+    }
 
     // Copy other variables
     set_patch_value(symshdr, syment, symstringdata, "is_running_dolphin", is_running_dolphin);

--- a/cubeboot/source/settings.c
+++ b/cubeboot/source/settings.c
@@ -70,18 +70,18 @@ void load_settings() {
         settings.cube_logo = (char*)cube_logo;
     }
 
-    // default program
-    const char *default_program = ini_get(conf, "cubeboot", "default_program");
-    if (default_program != NULL) {
-        iprintf("Found default_program = %s\n", default_program);
-        settings.default_program = (char*)default_program;
-    }
-
     // default folder
     const char *default_folder = ini_get(conf, "cubeboot", "default_folder");
     if (default_folder != NULL) {
         iprintf("Found default_folder = %s\n", default_folder);
         settings.default_folder = (char*)default_folder;
+    }
+
+    // default program
+    const char *default_program = ini_get(conf, "cubeboot", "default_program");
+    if (default_program != NULL) {
+        iprintf("Found default_program = %s\n", default_program);
+        settings.default_program = (char*)default_program;
     }
 
     // swiss enable

--- a/cubeboot/source/settings.c
+++ b/cubeboot/source/settings.c
@@ -77,6 +77,13 @@ void load_settings() {
         settings.default_program = (char*)default_program;
     }
 
+    // default folder
+    const char *default_folder = ini_get(conf, "cubeboot", "default_folder");
+    if (default_folder != NULL) {
+        iprintf("Found default_folder = %s\n", default_folder);
+        settings.default_folder = (char*)default_folder;
+    }
+
     // swiss enable
     int force_swiss_default = 0;
     if (!ini_sget(conf, "cubeboot", "force_swiss_default", "%d", &force_swiss_default)) {

--- a/cubeboot/source/settings.h
+++ b/cubeboot/source/settings.h
@@ -12,6 +12,7 @@ typedef struct settings {
     u32 preboot_delay_ms;
     u32 postboot_delay_ms;
     char *default_program;
+    char *default_folder;
     char *boot_buttons[MAX_BUTTONS];
 } settings_t;
 

--- a/cubeboot/source/settings.h
+++ b/cubeboot/source/settings.h
@@ -5,6 +5,7 @@
 typedef struct settings {
     u32 cube_color;
     char *cube_logo;
+    char *default_folder;
     u32 force_swiss_default;
     u32 show_watermark;
     u32 disable_mcp_select;
@@ -12,7 +13,6 @@ typedef struct settings {
     u32 preboot_delay_ms;
     u32 postboot_delay_ms;
     char *default_program;
-    char *default_folder;
     char *boot_buttons[MAX_BUTTONS];
 } settings_t;
 

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -348,6 +348,30 @@ __attribute_used__ void mod_cube_anim() {
     }
 }
 
+__attribute_used__ char* get_valid_path() {
+    if (default_folder[0] == '\0') {
+        OSReport("No default folder set, opening root\n");
+        return "/";
+    }
+
+    static char path[MAX_FILE_NAME];
+    if (default_folder[0] != '/') {
+        snprintf(path, sizeof(path), "/%s", default_folder);
+    } else {
+        strncpy(path, default_folder, sizeof(path));
+        path[sizeof(path) - 1] = '\0';
+    }
+
+    if (dvd_custom_open(path, FILE_ENTRY_TYPE_DIR, 0) != 0) {
+        OSReport("Could not open default folder: %s, opening root\n", path);
+        return "/";
+    }
+    dvd_custom_close(dvd_custom_status()->fd);
+
+    OSReport("Using default folder: %s\n", path);
+    return path;
+}
+
 __attribute_used__ void pre_thread_init() {
     dolphin_ARAMInit();
     orig_thread_init();
@@ -356,12 +380,7 @@ __attribute_used__ void pre_thread_init() {
     gm_init_thread();
 
     if (!start_passthrough_game) {
-        if (dvd_custom_open(default_folder, FILE_ENTRY_TYPE_DIR, 0) == 0) {
-            dvd_custom_close(dvd_custom_status()->fd);
-            gm_start_thread(default_folder);
-        } else {
-            gm_start_thread("/");
-        }
+        gm_start_thread(get_valid_path());
     }
 }
 

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -45,9 +45,9 @@ __attribute_data__ u32 start_passthrough_game = 0;
 
 __attribute_data__ static u8 *cube_text_tex = NULL;
 __attribute_data__ char cube_logo_path[MAX_FILE_NAME] = {0};
+__attribute_data__ char default_folder[MAX_FILE_NAME] = {0};
 __attribute_data__ u32 force_progressive = 0;
 __attribute_data__ u32 force_swiss_boot = 0;
-__attribute_data__ char default_folder[MAX_FILE_NAME] = {0};
 
 // used if we are switching to 60Hz on a PAL IPL
 __attribute_data__ static int fix_pal_ntsc = 0;
@@ -348,18 +348,17 @@ __attribute_used__ void mod_cube_anim() {
     }
 }
 
-__attribute_used__ char* get_valid_path() {
+__attribute_used__ char* resolve_default_folder() {
     if (default_folder[0] == '\0') {
         OSReport("No default folder set, opening root\n");
         return "/";
     }
 
-    static char path[MAX_FILE_NAME];
+    const char *path = default_folder;
+    static char path_buf[MAX_FILE_NAME];
     if (default_folder[0] != '/') {
-        snprintf(path, sizeof(path), "/%s", default_folder);
-    } else {
-        strncpy(path, default_folder, sizeof(path));
-        path[sizeof(path) - 1] = '\0';
+        snprintf(path_buf, sizeof(path_buf), "/%s", default_folder);
+        path = path_buf;
     }
 
     if (dvd_custom_open(path, FILE_ENTRY_TYPE_DIR, 0) != 0) {
@@ -378,9 +377,8 @@ __attribute_used__ void pre_thread_init() {
 
     gm_init_heap();
     gm_init_thread();
-
     if (!start_passthrough_game) {
-        gm_start_thread(get_valid_path());
+        gm_start_thread(resolve_default_folder());
     }
 }
 

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -47,6 +47,7 @@ __attribute_data__ static u8 *cube_text_tex = NULL;
 __attribute_data__ char cube_logo_path[MAX_FILE_NAME] = {0};
 __attribute_data__ u32 force_progressive = 0;
 __attribute_data__ u32 force_swiss_boot = 0;
+__attribute_data__ char default_folder[MAX_FILE_NAME] = {0};
 
 // used if we are switching to 60Hz on a PAL IPL
 __attribute_data__ static int fix_pal_ntsc = 0;
@@ -353,8 +354,14 @@ __attribute_used__ void pre_thread_init() {
 
     gm_init_heap();
     gm_init_thread();
+
     if (!start_passthrough_game) {
-        gm_start_thread("/");
+        if (dvd_custom_open(default_folder, FILE_ENTRY_TYPE_DIR, 0) == 0) {
+            dvd_custom_close(dvd_custom_status()->fd);
+            gm_start_thread(default_folder);
+        } else {
+            gm_start_thread("/");
+        }
     }
 }
 


### PR DESCRIPTION
Set the default folder in config.ini with the key `default_folder`.
Example:
```ini
default_folder = games
```
Cubiboot will start with that folder open instead of in the root of the SD card.

I tested the cubiboot.dol on a GameCube with picoboot v0.5.0.

All of these opened the games folder on boot correctly:
```ini
default_folder = games
default_folder = games/
default_folder = /games
default_folder = /games/
```

Setting default_folder to a directory that doesn't exist will just open the root of the SD like normal.